### PR TITLE
Normalize expression

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,0 +1,10 @@
+use crate::node::Node;
+use crate::node::type_of;
+
+pub fn is_same_type(node1: Node, node2: Node) -> bool {
+    type_of(node1) == type_of(node2)
+}
+
+pub fn is_same(node1: Node, node2: Node) -> bool {
+    is_same_type(node1.clone(), node2.clone()) && node1 == node2
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,12 +106,10 @@ mod tests {
         )
     }
 
-    // #[test]
-    // fn type_of_term() {
-    //     use crate::node::type_of;
-    //     use crate::node::Type;
-    //     assert_eq!(type_of(Atom("yo")), Type::Atom);
-    //     // assert_eq!(type_of(List(vec![])), Type::Pair());
-    //     assert_eq!(type_of(Type)), Type::Universe(1));
-    // }
+    #[test]
+    fn type_of_term() {
+        use crate::node::type_of;
+        use crate::node::Type;
+        assert_eq!(type_of(Atom("yo")), Type::Atom);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,8 @@ pub mod node;
 
 #[cfg(test)]
 mod tests {
-    use crate::node::*;
     use crate::node::Node::*;
-
+    use crate::node::*;
     #[test]
     fn atom_cmp() {
         assert_eq!(Atom("ratatouille"), Atom("ratatouille"));
@@ -12,58 +11,116 @@ mod tests {
     }
 
     #[test]
-    fn list_cmp() {
+    fn pair_cmp() {
         assert_eq!(
-            List(vec![Atom("ratatouille")]),
-            List(vec![Atom("ratatouille")])
+            PairNode(Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Atom("ratatouille")),
+            }),
+            PairNode(Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Atom("ratatouille")),
+            })
         );
 
         assert_ne!(
-            List(vec![Atom("ratatouille")]),
-            List(vec![Atom("baguette")])
+            PairNode(Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Atom("ratatouille")),
+            }),
+            PairNode(Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Atom("baguette")),
+            })
+        );
+
+        assert_ne!(
+            PairNode(Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Atom("ratatouille")),
+            }),
+            PairNode(Pair {
+                0: Box::new(Atom("baguette")),
+                1: Box::new(Atom("ratatouille")),
+            })
+        );
+
+        assert_ne!(
+            PairNode(Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Atom("baguette")),
+            }),
+            PairNode(Pair {
+                0: Box::new(Atom("baguette")),
+                1: Box::new(Atom("baguette")),
+            })
+        );
+
+        assert_ne!(
+            PairNode(Pair {
+                0: Box::new(Atom("baguette")),
+                1: Box::new(Atom("baguette")),
+            }),
+            PairNode(Pair {
+                0: Box::new(Atom("baguette")),
+                1: Box::new(Atom("ratatouille")),
+            })
         );
     }
 
     #[test]
-    fn list_cons() {
-        use crate::node::cons;
+    fn pair_cons() {
         assert_eq!(
-            cons(vec![Atom("ratatouille")], "baguette"),
-            List(vec![Atom("ratatouille"), Atom("baguette")])
+            Pair::cons(Atom("ratatouille"), Atom("baguette")),
+            Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Atom("baguette")),
+            }
         )
     }
 
     #[test]
-    fn list_car() {
-        use crate::node::car;
+    fn pair_car() {
         assert_eq!(
-            car(vec![Atom("ratatouille"), Atom("baguette")]),
+            Pair::car(Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Atom("baguette")),
+            }),
             Atom("ratatouille")
         );
     }
 
     #[test]
-    fn list_cdr() {
-        use crate::node::cdr;
+    fn pair_cdr() {
         assert_eq!(
-            cdr(vec![Atom("ratatouille"), Atom("baguette")]),
-            List(vec![Atom("baguette")])
+            Pair::cdr(Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Atom("baguette")),
+            }),
+            Atom("baguette")
         );
 
         assert_eq!(
-            cdr(vec![
-                Atom("ratatouille"),
-                Atom("baguette"),
-                Atom("aubergine")
-            ]),
-            List(vec![Atom("baguette"), Atom("aubergine")])
+            Pair::cdr(Pair {
+                0: Box::new(Atom("ratatouille")),
+                1: Box::new(Node::PairNode(Pair {
+                    0: Box::new(Atom("baguette")),
+                    1: Box::new(Atom("aubergine")),
+                }))
+            }),
+            Node::PairNode(Pair {
+                0: Box::new(Atom("baguette")),
+                1: Box::new(Atom("aubergine")),
+            })
         )
     }
 
-    #[test]
-    fn type_of_term() {
-        assert_eq!(type_of(Atom("yo")), Type(0));
-        assert_eq!(type_of(List(vec![])), Type(0));
-        assert_eq!(type_of(Type(0)), Type(1))
-    }
+    // #[test]
+    // fn type_of_term() {
+    //     use crate::node::type_of;
+    //     use crate::node::Type;
+    //     assert_eq!(type_of(Atom("yo")), Type::Atom);
+    //     // assert_eq!(type_of(List(vec![])), Type::Pair());
+    //     assert_eq!(type_of(Type)), Type::Universe(1));
+    // }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,20 @@
 pub mod node;
+pub mod helper;
 
 #[cfg(test)]
-mod tests {
+mod atom_test {
     use crate::node::Node::*;
-    use crate::node::*;
     #[test]
     fn atom_cmp() {
         assert_eq!(Atom("ratatouille"), Atom("ratatouille"));
         assert_ne!(Atom("ratatouille"), Atom("baguette"))
     }
+}
 
+#[cfg(test)]
+mod pair_test {
+    use crate::node::Node::*;
+    use crate::node::*;
     #[test]
     fn pair_cmp() {
         assert_eq!(
@@ -111,5 +116,17 @@ mod tests {
         use crate::node::type_of;
         use crate::node::Type;
         assert_eq!(type_of(Atom("yo")), Type::Atom);
+        assert_eq!(type_of(TypeNode(Type::Universe(0))), Type::Universe(1));
+        assert_eq!(type_of(TypeNode(Type::Universe(1))), Type::Universe(2));
+    }
+}
+
+#[cfg(test)]
+mod judgement {
+    use crate::node::Node::*;
+    use crate::helper::*;
+    #[test]
+    fn same_type() {
+        assert_eq!(is_same_type(Atom("a"), Atom("b")), true)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,58 +13,52 @@ mod tests {
     #[test]
     fn pair_cmp() {
         assert_eq!(
-            PairNode(Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Atom("ratatouille")),
-            }),
-            PairNode(Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Atom("ratatouille")),
-            })
+            PairNode(Pair(
+                Box::new(Atom("ratatouille")),
+                Box::new(Atom("ratatouille")),
+            )),
+            PairNode(Pair(
+                Box::new(Atom("ratatouille")),
+                Box::new(Atom("ratatouille")),
+            ))
         );
 
         assert_ne!(
-            PairNode(Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Atom("ratatouille")),
-            }),
-            PairNode(Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Atom("baguette")),
-            })
+            PairNode(Pair(
+                Box::new(Atom("ratatouille")),
+                Box::new(Atom("ratatouille"))
+            )),
+            PairNode(Pair(
+                Box::new(Atom("ratatouille")),
+                Box::new(Atom("baguette")),
+            ))
         );
 
         assert_ne!(
-            PairNode(Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Atom("ratatouille")),
-            }),
-            PairNode(Pair {
-                0: Box::new(Atom("baguette")),
-                1: Box::new(Atom("ratatouille")),
-            })
+            PairNode(Pair(
+                Box::new(Atom("ratatouille")),
+                Box::new(Atom("ratatouille")),
+            )),
+            PairNode(Pair(
+                Box::new(Atom("baguette")),
+                Box::new(Atom("ratatouille")),
+            ))
         );
 
         assert_ne!(
-            PairNode(Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Atom("baguette")),
-            }),
-            PairNode(Pair {
-                0: Box::new(Atom("baguette")),
-                1: Box::new(Atom("baguette")),
-            })
+            PairNode(Pair(
+                Box::new(Atom("ratatouille")),
+                Box::new(Atom("baguette")),
+            )),
+            PairNode(Pair(Box::new(Atom("baguette")), Box::new(Atom("baguette")),))
         );
 
         assert_ne!(
-            PairNode(Pair {
-                0: Box::new(Atom("baguette")),
-                1: Box::new(Atom("baguette")),
-            }),
-            PairNode(Pair {
-                0: Box::new(Atom("baguette")),
-                1: Box::new(Atom("ratatouille")),
-            })
+            PairNode(Pair(Box::new(Atom("baguette")), Box::new(Atom("baguette")),)),
+            PairNode(Pair(
+                Box::new(Atom("baguette")),
+                Box::new(Atom("ratatouille")),
+            ))
         );
     }
 
@@ -72,20 +66,17 @@ mod tests {
     fn pair_cons() {
         assert_eq!(
             Pair::cons(Atom("ratatouille"), Atom("baguette")),
-            Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Atom("baguette")),
-            }
+            Pair(Box::new(Atom("ratatouille")), Box::new(Atom("baguette")),)
         )
     }
 
     #[test]
     fn pair_car() {
         assert_eq!(
-            Pair::car(Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Atom("baguette")),
-            }),
+            Pair::car(Pair(
+                Box::new(Atom("ratatouille")),
+                Box::new(Atom("baguette"))
+            )),
             Atom("ratatouille")
         );
     }
@@ -93,25 +84,25 @@ mod tests {
     #[test]
     fn pair_cdr() {
         assert_eq!(
-            Pair::cdr(Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Atom("baguette")),
-            }),
+            Pair::cdr(Pair(
+                Box::new(Atom("ratatouille")),
+                Box::new(Atom("baguette")),
+            )),
             Atom("baguette")
         );
 
         assert_eq!(
-            Pair::cdr(Pair {
-                0: Box::new(Atom("ratatouille")),
-                1: Box::new(Node::PairNode(Pair {
-                    0: Box::new(Atom("baguette")),
-                    1: Box::new(Atom("aubergine")),
-                }))
-            }),
-            Node::PairNode(Pair {
-                0: Box::new(Atom("baguette")),
-                1: Box::new(Atom("aubergine")),
-            })
+            Pair::cdr(Pair(
+                Box::new(Atom("ratatouille")),
+                Box::new(Node::PairNode(Pair(
+                    Box::new(Atom("baguette")),
+                    Box::new(Atom("aubergine")),
+                ))),
+            )),
+            Node::PairNode(Pair(
+                Box::new(Atom("baguette")),
+                Box::new(Atom("aubergine")),
+            ))
         )
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -8,7 +8,7 @@ pub enum Node {
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Type {
-    Universe(u32),
+    Universe(i64),
     AtomTy,
     PairTy(Pair<Type>),
     Unit,
@@ -22,12 +22,12 @@ impl<T> Pair<T> {
         Pair(Box::new(node1), Box::new(node2))
     }
 
-    pub fn car(pair: Pair<T>) -> T {
-        *pair.0
+    pub fn car(self) -> T {
+        *self.0
     }
 
-    pub fn cdr(pair: Pair<T>) -> T {
-        *pair.1
+    pub fn cdr(self) -> T {
+        *self.1
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,37 +1,40 @@
 #[derive(Clone, PartialEq, Debug)]
 pub enum Node {
-    Atom(Atom),
-    List(List),
-    Type(i64)
+    Atom(&'static str),
+    Pair(Box<Node>, Box<Node>),
+    Type(Type),
 }
 
-pub type Atom = &'static str;
-
-// =====================================
-// List
-// =====================================
-pub type List = Vec<Node>;
-
-pub fn cons(list: List, atom: Atom) -> Node {
-    let mut cloned_list = list.clone();
-    cloned_list.push(Node::Atom(atom));
-    Node::List(cloned_list)
+#[derive(Clone, PartialEq, Debug)]
+pub enum Type {
+    Universe(i64),
+    Atom,
+    Pair(Box<Type>, Box<Type>)
 }
 
-pub fn car(list: List) -> Node {
-    list.first().unwrap().clone()
+pub fn cons(node: Node, atom: Node) -> Node {
+    Node::Pair(Box::new(node), Box::new(atom))
 }
 
-pub fn cdr(list: List) -> Node {
-    let mut cloned_list = list.clone();
-    cloned_list.remove(0);
-    Node::List(cloned_list)
-}
-
-pub fn type_of(node: Node) -> Node {
+pub fn car(node: Node) -> Result<Node, &'static str> {
     match node {
-        Node::Atom(_) => Node::Type(0),
-        Node::List(_) => Node::Type(0),
-        Node::Type(n) => Node::Type(n + 1)
+        Node::Pair(a, _) => Result::Ok(*a),
+        _ => Result::Err("Can only apply car to Pair")
+    }
+}
+
+pub fn cdr(node: Node) -> Result<Node, &'static str> {
+    match node {
+        Node::Pair(_, b) => Result::Ok(*b),
+        _ => Result::Err("Cannot apply cdr to Pair")
+    }
+}
+
+pub fn type_of(node: Node) -> Type {
+    match node {
+        Node::Atom(_) => Type::Atom,
+        Node::Pair(a, b) => Type::Pair(Box::new(type_of(*a)), Box::new(type_of(*b))),
+        Node::Type(Type::Universe(n)) => Type::Universe(n + 1),
+        Node::Type(_) => Type::Universe(0)
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,8 +9,8 @@ pub enum Node {
 #[derive(Clone, PartialEq, Debug)]
 pub enum Type {
     Universe(i64),
-    AtomTy,
-    PairTy(Pair<Type>),
+    Atom,
+    Pair(Pair<Type>),
     Unit,
 }
 
@@ -33,8 +33,8 @@ impl<T> Pair<T> {
 
 pub fn type_of(node: Node) -> Type {
     match node {
-        Node::Atom(_) => Type::AtomTy,
-        Node::PairNode(p) => Type::PairTy(Pair(Box::new(type_of(*p.0)), Box::new(type_of(*p.1)))),
+        Node::Atom(_) => Type::Atom,
+        Node::PairNode(p) => Type::Pair(Pair(Box::new(type_of(*p.0)), Box::new(type_of(*p.1)))),
         Node::TypeNode(Type::Universe(n)) => Type::Universe(n + 1),
         Node::TypeNode(_) => Type::Universe(0),
         Node::Unit => Type::Unit,

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,40 +1,42 @@
 #[derive(Clone, PartialEq, Debug)]
 pub enum Node {
     Atom(&'static str),
-    Pair(Box<Node>, Box<Node>),
-    Type(Type),
+    PairNode(Pair<Node>),
+    TypeNode(Type),
+    Unit,
 }
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Type {
-    Universe(i64),
-    Atom,
-    Pair(Box<Type>, Box<Type>)
+    Universe(u32),
+    AtomTy,
+    PairTy(Pair<Type>),
+    Unit,
 }
 
-pub fn cons(node: Node, atom: Node) -> Node {
-    Node::Pair(Box::new(node), Box::new(atom))
-}
+#[derive(Clone, PartialEq, Debug)]
+pub struct Pair<T>(pub Box<T>, pub Box<T>);
 
-pub fn car(node: Node) -> Result<Node, &'static str> {
-    match node {
-        Node::Pair(a, _) => Result::Ok(*a),
-        _ => Result::Err("Can only apply car to Pair")
+impl<T> Pair<T> {
+    pub fn cons(node1: T, node2: T) -> Pair<T> {
+        Pair(Box::new(node1), Box::new(node2))
     }
-}
 
-pub fn cdr(node: Node) -> Result<Node, &'static str> {
-    match node {
-        Node::Pair(_, b) => Result::Ok(*b),
-        _ => Result::Err("Cannot apply cdr to Pair")
+    pub fn car(pair: Pair<T>) -> T {
+        *pair.0
+    }
+
+    pub fn cdr(pair: Pair<T>) -> T {
+        *pair.1
     }
 }
 
 pub fn type_of(node: Node) -> Type {
     match node {
-        Node::Atom(_) => Type::Atom,
-        Node::Pair(a, b) => Type::Pair(Box::new(type_of(*a)), Box::new(type_of(*b))),
-        Node::Type(Type::Universe(n)) => Type::Universe(n + 1),
-        Node::Type(_) => Type::Universe(0)
+        Node::Atom(_) => Type::AtomTy,
+        Node::PairNode(p) => Type::PairTy(Pair(Box::new(type_of(*p.0)), Box::new(type_of(*p.1)))),
+        Node::TypeNode(Type::Universe(n)) => Type::Universe(n + 1),
+        Node::TypeNode(_) => Type::Universe(0),
+        Node::Unit => Type::Unit,
     }
 }


### PR DESCRIPTION
This pull request is to make a function that turns expression into its normal form.

> Given a type, every expression described by that type has a *normal form*, which is the most direct way of writing it. If two expressions are the same, then they have identical normal forms, and if they have identical normal forms, then they are the same.